### PR TITLE
Corrige conflito de controllers e ajusta `Convidado.EmailConfirmed`

### DIFF
--- a/ProjetoEventX/Controllers/TemplateConviteController.cs
+++ b/ProjetoEventX/Controllers/TemplateConviteController.cs
@@ -15,7 +15,7 @@ namespace ProjetoEventX.Controllers
 {
     [Authorize]
     [ServiceFilter(typeof(SecurityActionFilter))]
-    public class ConviteController : Controller
+    public class TemplateConviteController : Controller
     {
         private readonly EventXContext _context;
         private readonly UserManager<ApplicationUser> _userManager;
@@ -24,7 +24,7 @@ namespace ProjetoEventX.Controllers
         private readonly NotificationService _notificationService;
         private readonly EventLogService _eventLogService;
 
-        public ConviteController(
+        public TemplateConviteController(
             EventXContext context,
             UserManager<ApplicationUser> userManager,
             AuditoriaService auditoriaService,

--- a/ProjetoEventX/Models/Convidado.cs
+++ b/ProjetoEventX/Models/Convidado.cs
@@ -22,6 +22,6 @@ namespace ProjetoEventX.Models
         public ICollection<ListaConvidado> ListasConvidados { get; set; } = new List<ListaConvidado>();
             [System.ComponentModel.DataAnnotations.Schema.NotMapped]
             public ListaConvidado ListaConvidado { get; set; }
-            public bool EmailConfirmed { get; set; }
+            public new bool EmailConfirmed { get; set; }
     }
 }


### PR DESCRIPTION
### Motivation
- Havia duas definições de `ConviteController` causando ambiguidades e erros de compilação ao referenciar campos como `_context` e `_userManager`.
- A propriedade `EmailConfirmed` em `Convidado` escondia o membro herdado de `IdentityUser<int>` e gerava aviso de ocultação.

### Description
- Renomeada a classe declarada em `ProjetoEventX/Controllers/TemplateConviteController.cs` para `TemplateConviteController` e ajustado o construtor para `TemplateConviteController(...)` para remover o conflito com `ConviteController`.
- Atualizada a propriedade em `ProjetoEventX/Models/Convidado.cs` para `public new bool EmailConfirmed { get; set; }` para eliminar o aviso de ocultação do membro herdado.

### Testing
- Executado `dotnet build ProjetoEventX.sln`, porém o ambiente não possui `dotnet` disponível, portanto a compilação automática falhou com `dotnet: command not found`.
- Validação de alteração de código por inspeção e buscas de símbolos foi realizada localmente no repositório para confirmar que não existem definições duplicadas restantes e que a alteração em `Convidado` remove o aviso de ocultação.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd489ca6f48329834a540f11f499f6)