### PR TITLE
Renomeia grid customizada da dashboard para `dash-col-*` para evitar conflito com Bootstrap

### DIFF
--- a/ProjetoEventX/Views/Organizador/Dashboard.cshtml
+++ b/ProjetoEventX/Views/Organizador/Dashboard.cshtml
@@ -641,7 +641,7 @@
         }
 
         @@media (max-width: 1199.98px) {
-            .col-8, .col-7, .col-5, .col-4, .col-3 {
+            .dash-col-8, .dash-col-7, .dash-col-5, .dash-col-4, .dash-col-3 {
                 grid-column: span 12;
             }
 
@@ -697,7 +697,7 @@
 
 <div class="dash-shell animate-in">
     <div class="dash-grid">
-        <section class="col-12 stripe-hero">
+        <section class="dash-col-12 stripe-hero">
             <div class="row g-4 stripe-hero-inner align-items-center">
                 <div class="col-xl-8">
                     <span class="hero-badge">
@@ -756,7 +756,7 @@
             </div>
         </section>
 
-        <section class="col-3 metric-card-pro">
+        <section class="dash-col-3 metric-card-pro">
             <div class="metric-card-pro-body">
                 <div class="metric-top">
                     <div class="metric-icon-pro" style="background: linear-gradient(135deg, #992008, #E74C3C);">
@@ -771,7 +771,7 @@
             </div>
         </section>
 
-        <section class="col-3 metric-card-pro">
+        <section class="dash-col-3 metric-card-pro">
             <div class="metric-card-pro-body">
                 <div class="metric-top">
                     <div class="metric-icon-pro" style="background: linear-gradient(135deg, #059669, #10B981);">
@@ -786,7 +786,7 @@
             </div>
         </section>
 
-        <section class="col-3 metric-card-pro">
+        <section class="dash-col-3 metric-card-pro">
             <div class="metric-card-pro-body">
                 <div class="metric-top">
                     <div class="metric-icon-pro" style="background: linear-gradient(135deg, #D97706, #F59E0B);">
@@ -801,7 +801,7 @@
             </div>
         </section>
 
-        <section class="col-3 metric-card-pro">
+        <section class="dash-col-3 metric-card-pro">
             <div class="metric-card-pro-body">
                 <div class="metric-top">
                     <div class="metric-icon-pro" style="background: linear-gradient(135deg, #2563EB, #60A5FA);">
@@ -816,7 +816,7 @@
             </div>
         </section>
 
-        <section class="col-7 panel-card">
+        <section class="dash-col-7 panel-card">
             <div class="panel-card-header">
                 <div class="panel-title-wrap">
                     <div class="panel-title-icon" style="background: linear-gradient(135deg, #2563EB, #60A5FA);">
@@ -903,7 +903,7 @@
             </div>
         </section>
 
-        <section class="col-5 panel-card">
+        <section class="dash-col-5 panel-card">
             <div class="panel-card-header">
                 <div class="panel-title-wrap">
                     <div class="panel-title-icon" style="background: linear-gradient(135deg, #7C3AED, #A78BFA);">
@@ -961,7 +961,7 @@
             </div>
         </section>
 
-        <section class="col-7 panel-card">
+        <section class="dash-col-7 panel-card">
             <div class="panel-card-header">
                 <div class="panel-title-wrap">
                     <div class="panel-title-icon" style="background: linear-gradient(135deg, #0f172a, #334155);">
@@ -1031,7 +1031,7 @@
             </div>
         </section>
 
-        <section class="col-5 panel-card">
+        <section class="dash-col-5 panel-card">
             <div class="panel-card-header">
                 <div class="panel-title-wrap">
                     <div class="panel-title-icon" style="background: linear-gradient(135deg, #059669, #10B981);">
@@ -1099,7 +1099,7 @@
             </div>
         </section>
 
-        <section class="col-12 panel-card">
+        <section class="dash-col-12 panel-card">
             <div class="panel-card-header">
                 <div class="panel-title-wrap">
                     <div class="panel-title-icon" style="background: linear-gradient(135deg, #0f172a, #334155);">


### PR DESCRIPTION
### Motivation
- Corrigir layout quebrado da dashboard causado por conflito entre a grid customizada e classes do Bootstrap (`col-*`) que tornavam colunas muito finas e cards espremidos.
- Preservar todo o conteúdo e o visual premium da dashboard mantendo compatibilidade com o Bootstrap sem removê-lo.

### Description
- Renomeadas as classes de grid customizado de `col-3/4/5/7/8/12` para `dash-col-3/4/5/7/8/12` no bloco de CSS inline da view e nos seletores implicados.
- Atualizado todo o HTML da view `Views/Organizador/Dashboard.cshtml` para usar as classes `dash-col-*` nas seções que participam da `dash-grid` mantendo markup, textos e inline styles existentes.
- Ajustado o media query de responsividade (`max-width: 1199.98px`) para targetear as novas classes `dash-col-*` e evitar colapsos indevidos causados por seletores `.col-*` do Bootstrap.
- Mantidos todos os estilos inline (por exemplo backgrounds em `style="background: linear-gradient(...)"`) e a aparência premium dos cards e painéis.

### Testing
- Não existem testes automatizados unitários específicos para a view; validado estaticamente que as substituições foram aplicadas usando `rg` para localizar ocorrências remanescentes de `col-(3|4|5|7|8|12)` e inspeção do arquivo com `nl`/diff; as verificações confirmaram as alterações esperadas.
- Revisão do diff do arquivo mostrou que apenas os nomes das classes de grid e o media query foram alterados, sem remoção de conteúdo ou alteração visual do markup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceaa21c17083299d397b691e86c328)